### PR TITLE
Allows required inputs and overrides

### DIFF
--- a/lib/collector.rb
+++ b/lib/collector.rb
@@ -1,0 +1,8 @@
+class Collector
+  def collect_input(prompt)
+    puts prompt
+    if block_given?
+      yield(gets.squeeze(' ').strip.to_s)
+    end
+  end
+end

--- a/lib/config/load.rb
+++ b/lib/config/load.rb
@@ -1,6 +1,7 @@
 require 'httparty'
 require 'dotenv'
 require 'logger'
+require 'collector'
 require 'runner'
 require 'service'
 require 'process'

--- a/lib/firebat.rb
+++ b/lib/firebat.rb
@@ -1,7 +1,9 @@
 require 'config/load'
 require 'modules/logs_messages'
+require 'modules/collects_input'
 require 'rake'
 
 module Firebat
   extend LogsMessages
+  extend CollectsInput
 end

--- a/lib/modules/collects_input.rb
+++ b/lib/modules/collects_input.rb
@@ -1,0 +1,15 @@
+module CollectsInput
+  extend self
+
+  @@_collector = Collector.new
+
+  def collector=(collector)
+    @@_collector = collector
+  end
+
+  def collect_input(prompt)
+    @@_collector.collect_input(prompt) do |value|
+      yield(value) if block_given?
+    end
+  end
+end


### PR DESCRIPTION
This allows you to add required or overridable fields in a `Flow` like so:

```ruby
class MyFlow
  required_input :input_one
  overrideable_input :input_two
end
```

A `required_input` will prompt for a value if one is not provided by a chained flow (e.g. one ran prior and passed it in) or the value is `nil` IFF `ENABLE_REQUIRED_INPUT` is `true` in the environment.

An `overridable_input` will prompt for a value regardless of status IFF `ENABLE_OVERRIDES` is `true` in the environment.

If you're wondering why it's important to have `Firebat.collect_input` with an interchangeable module: it's supposed to mimic the `Firebat.log` setup so it can be manipulated with different frontends, e.g. if we build a web UI for it.

@dbelwood @ameliapadua @stevenfram 